### PR TITLE
Fix validation if at least a numeric value is 0

### DIFF
--- a/create.js
+++ b/create.js
@@ -87,8 +87,10 @@ process.argv.forEach((value, index) => {
   }
 });
 
-
-if (!duration || !spriteFileLocation || !outputVTTFileName || !gapBetweenFrames || !thumbnailWidth || !thumbnailHeight || !tileSize) {
+if (
+  [duration, gapBetweenFrames, thumbnailWidth, thumbnailHeight, tileSize].every(x => typeof x !== 'number') &&
+  (!duration || !spriteFileLocation || !outputVTTFileName || !gapBetweenFrames || !thumbnailWidth || !thumbnailHeight || !tileSize)
+  ) {
   console.log('Error: missing or invalid parameters in the command line');
   return;
 }


### PR DESCRIPTION
Fix a bug when the the script throws an error if at least one of the numeric parameters is zero.
Since the number "0" is a falsy value it can cause a false positive at the parameters validation.