### PR TITLE
Fix VTT timestamp generation

### DIFF
--- a/create.js
+++ b/create.js
@@ -28,7 +28,7 @@ const _secondsToHRTime = function (time) {
     let hours = 0;
     if (minutes > 59) {
       hours = Math.floor(time * 1.0 / 3600);
-      minutes = Math.floor(((time * 1.0 / 3600) % 1) * 60);
+      minutes = Math.floor((time - hours * 3600) / 60);
       seconds = Math.floor(time % 60);
     }
     if (seconds < 10) {


### PR DESCRIPTION
Floating-point rounding could result in incorrect minutes during conversion (for example, 5280 -> 1:27:00.000 instead of 1:28:00.000)